### PR TITLE
Disable mouse picking and dragging

### DIFF
--- a/containability.py
+++ b/containability.py
@@ -118,6 +118,7 @@ class Containability(object):
                 p.STATE_LOGGING_VIDEO_MP4, mp4_file_path)
 
         p.configureDebugVisualizer(p.COV_ENABLE_GUI, 0)
+        p.configureDebugVisualizer(p.COV_ENABLE_MOUSE_PICKING, 0)
 
         # Reset debug camera postion
         p.resetDebugVisualizerCamera(1.0, 0, -44, [-0.09, -0.1, 1])

--- a/pouring.py
+++ b/pouring.py
@@ -79,6 +79,8 @@ class CupPour(object):
             p.startStateLogging(p.STATE_LOGGING_VIDEO_MP4, mp4_file_path)
 
         p.configureDebugVisualizer(p.COV_ENABLE_GUI, 0)
+        p.configureDebugVisualizer(p.COV_ENABLE_MOUSE_PICKING, 0)
+
         # Reset debug camera postion
         p.resetDebugVisualizerCamera(0.7, 0, -40, [-0.05, -0.1, 1])
 


### PR DESCRIPTION
Disable mouse picking and dragging of the simulated object to prevent moving the object around and disrupting the course of the simulation.